### PR TITLE
Fixes

### DIFF
--- a/ProgressBar.xcodeproj/project.pbxproj
+++ b/ProgressBar.xcodeproj/project.pbxproj
@@ -65,10 +65,10 @@
 				BFD41BF41EC76F1F00CA2580 /* Main.storyboard */,
 				BFD41C021EC76FD600CA2580 /* DetailView.xib */,
 				BFD41C041EC76FE600CA2580 /* DetailView.swift */,
+				BFD41C061EC770C100CA2580 /* CustomProgressBar.swift */,
 				BFD41BF71EC76F1F00CA2580 /* Assets.xcassets */,
 				BFD41BF91EC76F1F00CA2580 /* LaunchScreen.storyboard */,
 				BFD41BFC1EC76F1F00CA2580 /* Info.plist */,
-				BFD41C061EC770C100CA2580 /* CustomProgressBar.swift */,
 			);
 			path = ProgressBar;
 			sourceTree = "<group>";
@@ -313,6 +313,7 @@
 				BFD41C011EC76F1F00CA2580 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ProgressBar/AppDelegate.swift
+++ b/ProgressBar/AppDelegate.swift
@@ -13,34 +13,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
 
 }
 

--- a/ProgressBar/Base.lproj/Main.storyboard
+++ b/ProgressBar/Base.lproj/Main.storyboard
@@ -21,13 +21,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vL4-9f-Qsc">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vL4-9f-Qsc">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="vL4-9f-Qsc" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="8CE-bP-M85"/>
+                            <constraint firstItem="vL4-9f-Qsc" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="Ay1-jB-h8k"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="vL4-9f-Qsc" secondAttribute="bottom" id="bez-D3-Yda"/>
+                            <constraint firstAttribute="trailing" secondItem="vL4-9f-Qsc" secondAttribute="trailing" id="yaH-5n-sua"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="containerView" destination="vL4-9f-Qsc" id="GJU-gl-c9u"/>

--- a/ProgressBar/CustomProgressBar.swift
+++ b/ProgressBar/CustomProgressBar.swift
@@ -55,11 +55,12 @@ class CustomProgressBar: UIView {
         if incremented <= bounds.width {
             let toPath = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: incremented + 100, height: bounds.height), cornerRadius: viewCornerRadius)
             
+            let fromPath = progressLayer.path
             progressLayer.path = toPath.cgPath
             borderLayer.addSublayer(progressLayer)
             
             let animation = CABasicAnimation(keyPath: "path")
-            animation.fromValue = progressLayer.path
+            animation.fromValue = fromPath
             animation.toValue = toPath.cgPath
             animation.duration = 3
             progressLayer.add(animation, forKey: animation.keyPath)

--- a/ProgressBar/CustomProgressBar.swift
+++ b/ProgressBar/CustomProgressBar.swift
@@ -17,9 +17,9 @@ class CustomProgressBar: UIView {
     var progressLayer = CAShapeLayer()
     
     
-    public init(width: CGFloat, height: CGFloat, color: CGColor?=nil, progressColor: CGColor?=nil, cornerRadius: CGFloat?=nil){
+    public init(width: CGFloat, height: CGFloat, color: CGColor? = nil, progressColor: CGColor? = nil, cornerRadius: CGFloat?=nil){
         if let radius = cornerRadius {
-            self.viewCornerRadius = radius
+            viewCornerRadius = radius
         }
         
         if let isColor = color {
@@ -38,17 +38,17 @@ class CustomProgressBar: UIView {
     }
     
     func draw() {
-        let bezierPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: viewCornerRadius)
+        let bezierPath = UIBezierPath(roundedRect: bounds, cornerRadius: viewCornerRadius)
         bezierPath.close()
         borderLayer.path = bezierPath.cgPath
-        borderLayer.fillColor = self.color
+        borderLayer.fillColor = color
         borderLayer.strokeEnd = 0
-        self.layer.addSublayer(borderLayer)
+        layer.addSublayer(borderLayer)
         
         let fromPath = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: 0, height: bounds.height), cornerRadius: viewCornerRadius)
-        self.progressLayer.path = fromPath.cgPath
-        self.progressLayer.fillColor = progressColor
-        self.borderLayer.addSublayer(self.progressLayer)
+        progressLayer.path = fromPath.cgPath
+        progressLayer.fillColor = progressColor
+        borderLayer.addSublayer(progressLayer)
     }
     
     func progress(incremented: CGFloat) {
@@ -59,7 +59,7 @@ class CustomProgressBar: UIView {
             borderLayer.addSublayer(progressLayer)
             
             let animation = CABasicAnimation(keyPath: "path")
-            animation.fromValue = self.progressLayer.path
+            animation.fromValue = progressLayer.path
             animation.toValue = toPath.cgPath
             animation.duration = 3
             progressLayer.add(animation, forKey: animation.keyPath)

--- a/ProgressBar/CustomProgressBar.swift
+++ b/ProgressBar/CustomProgressBar.swift
@@ -37,7 +37,7 @@ class CustomProgressBar: UIView {
         super.init(coder: aDecoder)
     }
     
-    func draw(){
+    func draw() {
         let bezierPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: viewCornerRadius)
         bezierPath.close()
         borderLayer.path = bezierPath.cgPath

--- a/ProgressBar/CustomProgressBar.swift
+++ b/ProgressBar/CustomProgressBar.swift
@@ -37,7 +37,7 @@ class CustomProgressBar: UIView {
         super.init(coder: aDecoder)
     }
     
-    func draw() {
+    func configure() {
         let bezierPath = UIBezierPath(roundedRect: bounds, cornerRadius: viewCornerRadius)
         bezierPath.close()
         borderLayer.path = bezierPath.cgPath

--- a/ProgressBar/DetailView.swift
+++ b/ProgressBar/DetailView.swift
@@ -11,10 +11,9 @@ import UIKit
 class DetailView: UIView {
 
     var pgBar: CustomProgressBar?
-    var value: Int?{
+    var value: Int? {
         didSet {
             progress(value: value!)
-            layoutSubviews()
         }
     }
     

--- a/ProgressBar/DetailView.swift
+++ b/ProgressBar/DetailView.swift
@@ -14,7 +14,7 @@ class DetailView: UIView {
     var value: Int?{
         didSet {
             progress(value: value!)
-            self.layoutSubviews()
+            layoutSubviews()
         }
     }
     
@@ -39,12 +39,12 @@ class DetailView: UIView {
     }
     
     func draw() {
-        self.pgBar = CustomProgressBar(width: progressContainer.bounds.width, height: progressContainer.bounds.height)
-        self.progressContainer.addSubview(self.pgBar!)
-        self.pgBar?.draw()
+        pgBar = CustomProgressBar(width: progressContainer.bounds.width, height: progressContainer.bounds.height)
+        progressContainer.addSubview(pgBar!)
+        pgBar?.draw()
     }
     
     func progress(value: Int) {
-        self.pgBar?.progress(incremented: CGFloat(value))
+        pgBar?.progress(incremented: CGFloat(value))
     }
 }

--- a/ProgressBar/DetailView.swift
+++ b/ProgressBar/DetailView.swift
@@ -29,21 +29,21 @@ class DetailView: UIView {
         initSubview()
     }
     
-    func initSubview(){
+    private func initSubview(){
         let nib = UINib(nibName: "DetailView", bundle: nil)
         nib.instantiate(withOwner: self, options: nil)
         addSubview(progressContainer)
         
-        draw()
+        addProgressBar()
     }
     
-    func draw() {
+    private func addProgressBar() {
         pgBar = CustomProgressBar(width: progressContainer.bounds.width, height: progressContainer.bounds.height)
         progressContainer.addSubview(pgBar!)
-        pgBar?.draw()
+        pgBar?.configure()
     }
     
-    func progress(value: Int) {
+    private func progress(value: Int) {
         pgBar?.progress(incremented: CGFloat(value))
     }
 }

--- a/ProgressBar/ViewController.swift
+++ b/ProgressBar/ViewController.swift
@@ -11,13 +11,20 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBOutlet weak var containerView: UIView!
+    weak var detailView: DetailView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let subview = DetailView(frame: view.frame)
+        containerView.addSubview(subview)
+        detailView = subview
+    }
 
-        let detailView = DetailView(frame: view.frame)
-        detailView.value = 60
-        containerView.addSubview(detailView)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        detailView?.value = 60
     }
 }
 

--- a/ProgressBar/ViewController.swift
+++ b/ProgressBar/ViewController.swift
@@ -14,15 +14,10 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-        let view = DetailView(frame: self.view.frame)
-        view.value = 60
-        self.containerView.addSubview(view)
-    }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+        let detailView = DetailView(frame: view.frame)
+        detailView.value = 60
+        containerView.addSubview(detailView)
     }
 }
 


### PR DESCRIPTION
The key issues were:

1. Save the `progressLayer`'s old path so you can start animation from there.
2. Never call `layoutSubviews()` directly.
3. Don't try to start animations if `viewDidLoad`. Use `viewDidAppear` (or whatever) instead.
4. Don't try to change the `value` of the `DetailView` before you've added it to the view hierarchy.

As an aside, I'd discourage view related methods called `draw`, because that has a very specific meaning in view classes (i.e. render the view).